### PR TITLE
Use summary memory with configurable limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ The AI Real Estate Advisor implements a Retrieval-Augmented Generation (RAG) sys
 - **Flexible LLM Integration**: Support for OpenAI GPT models and open-source alternatives
 - **Responsive Web Interface**: Easy-to-use Streamlit-based user interface
 
+### Conversation Memory
+The chatbot uses `ConversationSummaryBufferMemory` to keep track of the dialogue.
+When the chat history exceeds a configurable token limit, older messages are
+summarized automatically. Adjust this limit with the `MEMORY_TOKEN_LIMIT`
+setting in [`common/cfg.py`](common/cfg.py) or via the environment variable of
+the same name.
+
 ## Strengths & Limitations
 
 ### Strengths

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ import validators  # For validating URLs
 import streamlit as st  # Web UI framework
 from streaming import StreamHandler  # Custom handler for streaming responses
 from common.cfg import *  # Import configuration variables
-from langchain.memory import ConversationBufferMemory  # For storing conversation context
+from langchain.memory import ConversationSummaryBufferMemory  # For storing conversation context
 from langchain.chains import ConversationalRetrievalChain  # Main RAG chain
 import pandas as pd  # For data manipulation
 from langchain_core.documents.base import Document  # LangChain document structure
@@ -313,11 +313,13 @@ class ChatbotWeb:
                 search_kwargs={'k': 5}
             )
 
-        # Setup memory for contextual conversation
-        memory = ConversationBufferMemory(
+        # Setup memory for contextual conversation using automatic summarization
+        memory = ConversationSummaryBufferMemory(
+            llm=self.llm,
             memory_key='chat_history',  # Key used to access chat history in the chain
             output_key='answer',  # Key used to store the final answer
-            return_messages=True  # Return chat history as message objects
+            return_messages=True,  # Return chat history as message objects
+            max_token_limit=MEMORY_TOKEN_LIMIT,  # Summarize when token limit is reached
         )
 
         # Setup QA chain that combines the LLM, retriever, and memory

--- a/common/cfg.py
+++ b/common/cfg.py
@@ -9,6 +9,9 @@ from faker import Faker
 env_file = find_dotenv()
 load_dotenv(env_file, override=True)
 
+# Conversation memory configuration
+MEMORY_TOKEN_LIMIT = int(os.environ.get("MEMORY_TOKEN_LIMIT", 1000))
+
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 COHERE_API_KEY = os.environ.get("COHERE_API_KEY")
 HUGGINGFACEHUB_API_TOKEN = os.environ.get("HUGGINGFACEHUB_API_TOKEN")


### PR DESCRIPTION
## Summary
- switch to `ConversationSummaryBufferMemory` so older chat turns are summarized
- add `MEMORY_TOKEN_LIMIT` configuration option
- document summary-based memory and how to configure the limit

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a082fa56588323bf00d1f7904b78d6